### PR TITLE
Add optional embed fields, reload command, refactor webhook requests to be async

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.untone</groupId>
   <artifactId>DiscordJoinLeaveMessages</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>DiscordJoinLeaveMessages</name>

--- a/src/main/java/uk/untone/DiscordJoinLeaveMessages.java
+++ b/src/main/java/uk/untone/DiscordJoinLeaveMessages.java
@@ -1,29 +1,53 @@
 package uk.untone;
 
-import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import net.md_5.bungee.api.ChatColor;
+
 public final class DiscordJoinLeaveMessages extends JavaPlugin {
-    FileConfiguration config = getConfig();
 
     @Override
     public void onEnable() {
-        config.addDefault("webhook-url", "https://discord.com/api/webhooks/your-webhook");
-        config.addDefault("death-webhook-url", "");
-        config.options().copyDefaults(true);
+        saveDefaultConfig();
+
+        getConfig().options().copyDefaults(true);
         saveConfig();
 
-        if(config.getString("webhook-url") == "https://discord.com/api/webhooks/your-webhook") {
+        if(getConfig().getString("webhook-url") == "https://discord.com/api/webhooks/your-webhook") {
             getLogger().warning("Server does not have Webhook URL defined, please set up in config");
             return;
         }
 
-        getServer().getPluginManager().registerEvents(new PlayerListener(config.getString("webhook-url"), config.getString("death-webhook-url")), this);
+        getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
     }
 
 
     @Override
     public void onDisable() {
         // Plugin shutdown logic
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (command.getName().equalsIgnoreCase("djlm") && args.length == 0) {
+            sender.sendMessage("DiscordJoinLeaveMessages version " + getDescription().getVersion());
+            return true;
+        }
+
+        if (command.getName().equalsIgnoreCase("djlm") && args[0].equals("reload")) {
+            if (!sender.hasPermission("djlm.reload")) {
+                sender.sendMessage(ChatColor.RED + "You don't have permission to do that.");
+                return true;
+            }
+
+            reloadConfig();
+            sender.sendMessage(ChatColor.GREEN + "Config reloaded!");
+            return true;
+        }
+
+
+        return false;
     }
 }

--- a/src/main/java/uk/untone/DiscordJoinLeaveMessages.java
+++ b/src/main/java/uk/untone/DiscordJoinLeaveMessages.java
@@ -1,10 +1,9 @@
 package uk.untone;
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
-
-import net.md_5.bungee.api.ChatColor;
 
 public final class DiscordJoinLeaveMessages extends JavaPlugin {
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,5 @@
+webhook-url: "https://discord.com/api/webhooks/your-webhook"
+death-webhook-url: ""
+show-timestamp: true
+show-uuid: false
+show-client-brand: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,9 @@ name: DiscordJoinLeaveMessages
 version: '${project.version}'
 main: uk.untone.DiscordJoinLeaveMessages
 api-version: '1.21'
+
+commands:
+  djlm:
+    description: Reloads the config
+    usage: /djlm reload
+    permission: djlm.reload


### PR DESCRIPTION
I just discovered this plugin and like how simple it is. I use it as a way for admins to see who joined and left over Discord, but didn't want a heavy and complicated plugin like DiscordSRV, so thanks for making this!

Since I use it as an admin only addition, I added and improved a couple things for my own use case but figured I would make a PR incase these are things you would like for your plugin. This is what the new embed looks like with all new features enabled:
<img width="341" height="159" alt="image" src="https://github.com/user-attachments/assets/d99775ae-78db-402f-8f83-09ba9ef2552b" />

The client brand is only included in the join message.

I also added a reload command: `/djlm reload` as well as made sure webhook calls are done in a separate thread to stop the server from freezing temporarily while the plugin waits for a response from the Discord API.

also learned you guys are behind osekai which was unexpected, im top 2k in osu lol